### PR TITLE
fix sintax errors

### DIFF
--- a/OpenBoard/mainwindow.ui
+++ b/OpenBoard/mainwindow.ui
@@ -60,12 +60,12 @@
     <property name="title">
      <string>&amp;Board</string>
     </property>
-    <addaction name="actionSho_w"/>
+    <addaction name="action_Show"/>
     <addaction name="action_Hide"/>
     <addaction name="separator"/>
     <addaction name="action_Play"/>
-    <addaction name="actionP_ause"/>
-    <addaction name="actionS_top"/>
+    <addaction name="action_Pause"/>
+    <addaction name="action_Stop"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
     <property name="title">
@@ -188,7 +188,7 @@
     <string>&amp;Reset default</string>
    </property>
   </action>
-  <action name="actionSho_w">
+  <action name="action_Show">
    <property name="text">
     <string>Sho&amp;w</string>
    </property>
@@ -203,12 +203,12 @@
     <string>&amp;Play</string>
    </property>
   </action>
-  <action name="actionP_ause">
+  <action name="action_Pause">
    <property name="text">
     <string>P&amp;ause</string>
    </property>
   </action>
-  <action name="actionS_top">
+  <action name="action_Stop">
    <property name="text">
     <string>S&amp;top</string>
    </property>


### PR DESCRIPTION
fix actions names. All actions in MenuBar should be look like as: "action_[someNameOfAction]".
Example: button "New" in Menu - action_New 
